### PR TITLE
[WIP] Add angle delta for H_PRED and V_PRED

### DIFF
--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -141,6 +141,11 @@ pub fn intra_bench<T: Pixel>(
     PixelType::U8 => 8,
     PixelType::U16 => 10,
   };
+  let angle = match mode {
+    PredictionMode::H_PRED => 180,
+    PredictionMode::V_PRED => 90,
+    _ => 0,
+  };
   b.iter(|| {
     dispatch_predict_intra::<T>(
       mode,
@@ -149,7 +154,7 @@ pub fn intra_bench<T: Pixel>(
       TxSize::TX_4X4,
       bitdepth,
       &ac,
-      0,
+      angle,
       &edge_buf,
       cpu,
     );

--- a/benches/predict.rs
+++ b/benches/predict.rs
@@ -142,8 +142,8 @@ pub fn intra_bench<T: Pixel>(
     PixelType::U16 => 10,
   };
   let angle = match mode {
-    PredictionMode::H_PRED => 180,
     PredictionMode::V_PRED => 90,
+    PredictionMode::H_PRED => 180,
     _ => 0,
   };
   b.iter(|| {

--- a/src/asm/aarch64/predict.rs
+++ b/src/asm/aarch64/predict.rs
@@ -110,10 +110,18 @@ pub fn dispatch_predict_intra<T: Pixel>(
           })(dst_ptr, stride, edge_ptr, w, h, ac_ptr, angle);
         }
         PredictionMode::H_PRED => {
-          rav1e_ipred_h_neon(dst_ptr, stride, edge_ptr, w, h, angle);
+          if angle == 180 {
+            rav1e_ipred_h_neon(dst_ptr, stride, edge_ptr, w, h, angle);
+          } else {
+            call_native(dst);
+          }
         }
         PredictionMode::V_PRED => {
-          rav1e_ipred_v_neon(dst_ptr, stride, edge_ptr, w, h, angle);
+          if angle == 90 {
+            rav1e_ipred_v_neon(dst_ptr, stride, edge_ptr, w, h, angle);
+          } else {
+            call_native(dst);
+          }
         }
         PredictionMode::PAETH_PRED => {
           rav1e_ipred_paeth_neon(dst_ptr, stride, edge_ptr, w, h, angle);

--- a/src/asm/aarch64/predict.rs
+++ b/src/asm/aarch64/predict.rs
@@ -109,19 +109,11 @@ pub fn dispatch_predict_intra<T: Pixel>(
             PredictionVariant::BOTH => rav1e_ipred_cfl_neon,
           })(dst_ptr, stride, edge_ptr, w, h, ac_ptr, angle);
         }
-        PredictionMode::H_PRED => {
-          if angle == 180 {
-            rav1e_ipred_h_neon(dst_ptr, stride, edge_ptr, w, h, angle);
-          } else {
-            call_native(dst);
-          }
+        PredictionMode::V_PRED if angle == 90 => {
+          rav1e_ipred_v_neon(dst_ptr, stride, edge_ptr, w, h, angle);
         }
-        PredictionMode::V_PRED => {
-          if angle == 90 {
-            rav1e_ipred_v_neon(dst_ptr, stride, edge_ptr, w, h, angle);
-          } else {
-            call_native(dst);
-          }
+        PredictionMode::H_PRED if angle == 180 => {
+          rav1e_ipred_h_neon(dst_ptr, stride, edge_ptr, w, h, angle);
         }
         PredictionMode::PAETH_PRED => {
           rav1e_ipred_paeth_neon(dst_ptr, stride, edge_ptr, w, h, angle);

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -556,18 +556,21 @@ pub fn get_intra_edges<T: Pixel>(
       let dc_or_cfl =
         mode == PredictionMode::DC_PRED || mode == PredictionMode::UV_CFL_PRED;
 
-      needs_left = mode != PredictionMode::V_PRED
-        && (!dc_or_cfl || x != 0)
+      needs_left = (!dc_or_cfl || x != 0)
         && !(mode == PredictionMode::D45_PRED
           || mode == PredictionMode::D63_PRED);
       needs_topleft = mode == PredictionMode::PAETH_PRED
+        || mode == PredictionMode::H_PRED
+        || mode == PredictionMode::V_PRED
         || mode == PredictionMode::D117_PRED
         || mode == PredictionMode::D135_PRED
         || mode == PredictionMode::D153_PRED;
-      needs_top = mode != PredictionMode::H_PRED && (!dc_or_cfl || y != 0);
-      needs_topright =
-        mode == PredictionMode::D45_PRED || mode == PredictionMode::D63_PRED;
-      needs_bottomleft = mode == PredictionMode::D207_PRED;
+      needs_top = !dc_or_cfl || y != 0;
+      needs_topright = mode == PredictionMode::V_PRED
+        || mode == PredictionMode::D45_PRED
+        || mode == PredictionMode::D63_PRED;
+      needs_bottomleft =
+        mode == PredictionMode::H_PRED || mode == PredictionMode::D207_PRED;
     }
 
     // Needs left

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -155,6 +155,8 @@ impl PredictionMode {
 
     let angle = match mode {
       PredictionMode::UV_CFL_PRED => alpha as isize,
+      PredictionMode::H_PRED => 180,
+      PredictionMode::V_PRED => 90,
       PredictionMode::D45_PRED => 45,
       PredictionMode::D135_PRED => 135,
       PredictionMode::D117_PRED => 113,
@@ -184,8 +186,9 @@ impl PredictionMode {
   #[inline(always)]
   pub fn angle_delta_count(self) -> i8 {
     match self {
-      // TODO add H_PRED and V_PRED after implement angle delta for pred_h and pred_v
-      PredictionMode::D45_PRED
+      PredictionMode::H_PRED
+      | PredictionMode::V_PRED
+      | PredictionMode::D45_PRED
       | PredictionMode::D135_PRED
       | PredictionMode::D117_PRED
       | PredictionMode::D153_PRED
@@ -473,8 +476,38 @@ pub(crate) mod native {
         height,
         bit_depth,
       ),
-      PredictionMode::H_PRED => pred_h(dst, left_slice, width, height),
-      PredictionMode::V_PRED => pred_v(dst, above_slice, width, height),
+      PredictionMode::H_PRED => {
+        if angle == 180 {
+          pred_h(dst, left_slice, width, height)
+        } else {
+          pred_directional(
+            dst,
+            above_slice,
+            left_and_left_below_slice,
+            top_left,
+            angle as usize,
+            width,
+            height,
+            bit_depth,
+          )
+        }
+      }
+      PredictionMode::V_PRED => {
+        if angle == 90 {
+          pred_v(dst, above_slice, width, height)
+        } else {
+          pred_directional(
+            dst,
+            above_slice,
+            left_and_left_below_slice,
+            top_left,
+            angle as usize,
+            width,
+            height,
+            bit_depth,
+          )
+        }
+      }
       PredictionMode::PAETH_PRED => {
         pred_paeth(dst, above_slice, left_slice, top_left[0], width, height)
       }

--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -801,6 +801,7 @@ pub fn rdo_mode_decision<T: Pixel>(
     cw.bc.blocks.set_segmentation_idx(tile_bo, bsize, best.sidx);
 
     let chroma_mode = PredictionMode::UV_CFL_PRED;
+    let angle_delta = AngleDelta { y: best.angle_delta.y, uv: 0 };
     let cw_checkpoint = cw.checkpoint();
     let wr: &mut dyn Writer = &mut WriterCounter::new();
 
@@ -811,7 +812,7 @@ pub fn rdo_mode_decision<T: Pixel>(
       wr,
       best.pred_mode_luma,
       best.pred_mode_luma,
-      best.angle_delta,
+      angle_delta,
       tile_bo,
       bsize,
       best.tx_size,
@@ -849,7 +850,7 @@ pub fn rdo_mode_decision<T: Pixel>(
         wr,
         best.pred_mode_luma,
         chroma_mode,
-        best.angle_delta,
+        angle_delta,
         best.ref_frames,
         best.mvs,
         bsize,
@@ -876,6 +877,7 @@ pub fn rdo_mode_decision<T: Pixel>(
         best.pred_mode_chroma = chroma_mode;
         best.has_coeff = has_coeff;
         best.pred_cfl_params = cfl;
+        best.angle_delta = angle_delta;
       }
 
       cw.rollback(&cw_checkpoint);


### PR DESCRIPTION
For reference, these are the changes I made locally while reviewing:

- Tidy up matching rules
- Fix interaction with chroma-from-luma
- De-duplicate angles in tests

I think the interaction between `AngleDeltaUV` and `CflAlphaU`/`CflAlphaV` already exists - adding angle delta for  `H_PRED` and `V_PRED` just increases the probability of seeing it in tests.

I would like to align the names and ordering of `PredictionMode` values in the code with the AV1 spec. I can wait for your PR to land before applying that, if you prefer.